### PR TITLE
Bluexp 996 rns auto

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -1,5 +1,7 @@
 settings:
   name: Azure Blob storage
+  release_notes_autogen:
+      release_notes_repo: console-relnotes
   internal:
     pdf_enabled: true
   prod:

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -15,10 +15,8 @@ summary: Learn what's new with Azure Blob Storage in the NetApp Console.
 [.lead]
 Learn what's new with Azure Blob Storage in the NetApp Console.
 
-// tag::whats-new[]
 == 06 October 2025
 include::_whatsnew/2025-10-06.adoc[]
 
 == 05 June 2023
 include::_whatsnew/2023-06-05.adoc[]
-// end::whats-new[]


### PR DESCRIPTION
This pull request introduces a configuration update to enable automated release notes and makes a minor documentation change by removing unused tags from the "What's New" page.

Configuration improvements:

* Added a `release_notes_autogen` section to `project.yml` to specify the `release_notes_repo` as `console-relnotes`, enabling automated release notes generation.

Documentation cleanup:

* Removed unused comment tags (`// tag::whats-new[]` and `// end::whats-new[]`) from `whats-new.adoc` to simplify the documentation structure.